### PR TITLE
Feature/15 define scopes

### DIFF
--- a/Blazorade.Teams/Blazorade.Teams.xml
+++ b/Blazorade.Teams/Blazorade.Teams.xml
@@ -36,9 +36,16 @@
             </code>
             </example>
         </member>
-        <member name="P:Blazorade.Teams.Components.TeamsApplication.RequireAuthentication">
+        <member name="P:Blazorade.Teams.Components.TeamsApplication.RequireDefaultScopes">
             <summary>
-            Set to <c>true</c> to have the component take care of authenticating the user.
+            Specifies whether to perform authentication and acquire an access token with the default scopes
+            configured during application startup.
+            </summary>
+        </member>
+        <member name="P:Blazorade.Teams.Components.TeamsApplication.RequireScopes">
+            <summary>
+            A comma-separated list of scopes to acquire a token for. If <see cref="P:Blazorade.Teams.Components.TeamsApplication.RequireDefaultScopes"/> is set
+            to <c>true</c>, then the scopes acquired are combined with the default scopes.
             </summary>
         </member>
         <member name="P:Blazorade.Teams.Components.TeamsApplication.ApplicationTemplate">
@@ -127,12 +134,20 @@
             Defaults to <c>/login</c>.
             </remarks>
         </member>
+        <member name="P:Blazorade.Teams.Configuration.BlazoradeTeamsOptions.DefaultScopes">
+            <summary>
+            The default scopes to acquire if none are specified when acquiring tokens.
+            </summary>
+            <remarks>
+            Defaults to the defaults specified on <see cref="P:Blazorade.Msal.Configuration.BlazoradeMsalOptions.DefaultScopes"/>.
+            </remarks>
+        </member>
         <member name="T:Blazorade.Teams.Interop.AuthenticationModule">
             <summary>
             Represents the authentication module in the Teams SDK.
             </summary>
         </member>
-        <member name="M:Blazorade.Teams.Interop.AuthenticationModule.#ctor(Blazorade.Teams.Configuration.BlazoradeTeamsOptions,Microsoft.JSInterop.IJSRuntime,Microsoft.AspNetCore.Components.NavigationManager,Blazorade.Msal.Services.BlazoradeMsalService)">
+        <member name="M:Blazorade.Teams.Interop.AuthenticationModule.#ctor(Blazorade.Teams.Configuration.BlazoradeTeamsOptions,Microsoft.JSInterop.IJSRuntime,Microsoft.AspNetCore.Components.NavigationManager,Blazorade.Msal.Services.BlazoradeMsalService,Blazorade.Teams.Interop.Internal.LocalStorageService)">
             <inheritdoc/>
         </member>
         <member name="M:Blazorade.Teams.Interop.AuthenticationModule.NotifyFailureAsync(System.String,System.String)">

--- a/Blazorade.Teams/Components/LoginDialogHandler.razor
+++ b/Blazorade.Teams/Components/LoginDialogHandler.razor
@@ -3,6 +3,8 @@
 @inject BlazoradeMsalService MsalService
 @inject BlazoradeTeamsInteropModule TeamsInterop
 @inject NavigationManager NavMan
+@inject LocalStorageService LocalStorage
+@inject BlazoradeTeamsOptions Options
 
 @if(null != this.ChildContent)
 {

--- a/Blazorade.Teams/Configuration/BlazoradeTeamsConfigurationMethods.cs
+++ b/Blazorade.Teams/Configuration/BlazoradeTeamsConfigurationMethods.cs
@@ -1,6 +1,7 @@
 ﻿using Blazorade.Msal.Configuration;
 using Blazorade.Teams.Configuration;
 using Blazorade.Teams.Interop;
+using Blazorade.Teams.Interop.Internal;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,6 +33,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddScoped<ApplicationInitializationModule>()
                 .AddScoped<SettingsModule>()
                 .AddScoped<AuthenticationModule>()
+                .AddScoped<LocalStorageService>()
                 .AddBlazoradeMsal((sp, config) =>
                 {
                     var options = sp.GetService<BlazoradeTeamsOptions>();
@@ -39,6 +41,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     config.ClientId = options.ClientId;
                     config.TenantId = options.TenantId;
                     config.RedirectUrl = options.LoginUrl;
+                    config.DefaultScopes = options.DefaultScopes ?? config.DefaultScopes;
 
                     // We need to use the authentication dialog provided by Teams, in which we will perform a redirect authentication.
                     config.InteractiveLoginMode = InteractiveLoginMode.Redirect;

--- a/Blazorade.Teams/Configuration/BlazoradeTeamsOptions.cs
+++ b/Blazorade.Teams/Configuration/BlazoradeTeamsOptions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Blazorade.Msal.Configuration;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -17,6 +18,7 @@ namespace Blazorade.Teams.Configuration
         public BlazoradeTeamsOptions()
         {
             this.LoginUrl = "/login";
+            this.DefaultScopes = new BlazoradeMsalOptions().DefaultScopes;
         }
 
 
@@ -39,5 +41,12 @@ namespace Blazorade.Teams.Configuration
         /// </remarks>
         public string LoginUrl { get; set; }
 
+        /// <summary>
+        /// The default scopes to acquire if none are specified when acquiring tokens.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to the defaults specified on <see cref="BlazoradeMsalOptions.DefaultScopes"/>.
+        /// </remarks>
+        public IEnumerable<string> DefaultScopes { get; set; }
     }
 }

--- a/Blazorade.Teams/InternalExtensionMethods.cs
+++ b/Blazorade.Teams/InternalExtensionMethods.cs
@@ -10,27 +10,6 @@ namespace Blazorade.Teams
 {
     internal static class InternalExtensionMethods
     {
-        private const string LoginRedirectFragment = "redirect-to-login";
 
-        internal static Uri CreateLoginRedirectUri(this NavigationManager navMan, BlazoradeTeamsOptions options)
-        {
-            var loginUri = new Uri(options.LoginUrl, UriKind.RelativeOrAbsolute);
-            if (!loginUri.IsAbsoluteUri)
-            {
-                loginUri = navMan.ToAbsoluteUri(options.LoginUrl);
-            }
-
-            var builder = new UriBuilder(loginUri);
-            builder.Fragment = LoginRedirectFragment;
-            loginUri = builder.Uri;
-
-            return loginUri;
-        }
-
-        internal static bool IsLoginRedirectUri(this NavigationManager navMan)
-        {
-            var uri = new Uri(navMan.Uri);
-            return uri.Fragment?.Substring(1) == LoginRedirectFragment; //Starting from the second chart to compare, since the first char in the fragment is always '#'.
-        }
     }
 }

--- a/Blazorade.Teams/Interop/Internal/LocalStorageService.cs
+++ b/Blazorade.Teams/Interop/Internal/LocalStorageService.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.JSInterop;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Blazorade.Teams.Interop.Internal
+{
+    public class LocalStorageService
+    {
+        public LocalStorageService(IJSRuntime jsRuntime)
+        {
+            this.JSRuntime = jsRuntime ?? throw new ArgumentNullException(nameof(jsRuntime));
+        }
+
+        private readonly IJSRuntime JSRuntime;
+
+
+        public async Task ClearAsync()
+        {
+            await this.JSRuntime.InvokeVoidAsync("localStorage.clear");
+        }
+
+        public async Task<string> GetItemAsync(string key)
+        {
+            return await this.JSRuntime.InvokeAsync<string>("localStorage.getItem", key);
+        }
+
+        public async Task<T> GetItemAsync<T>(string key)
+        {
+            var json = await this.GetItemAsync(key);
+            return JsonSerializer.Deserialize<T>(json);
+        }
+
+        public async Task RemoveItemAsync(string key)
+        {
+            await this.JSRuntime.InvokeVoidAsync("localStorage.removeItem", key);
+        }
+
+        public async Task SetItemAsync(string key, string value)
+        {
+            await this.JSRuntime.InvokeVoidAsync("localStorage.setItem", key, value);
+        }
+
+        public async Task SetItemAsync(string key, object value)
+        {
+            string str = null;
+            if(null != value)
+            {
+                str = JsonSerializer.Serialize(value);
+            }
+
+            await this.SetItemAsync(key, str);
+        }
+    }
+}

--- a/Blazorade.Teams/Interop/Internal/TokenRequestInfo.cs
+++ b/Blazorade.Teams/Interop/Internal/TokenRequestInfo.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blazorade.Teams.Interop.Internal
+{
+    internal class TokenRequestInfo
+    {
+
+        public string LoginHint { get; set; }
+
+        public List<string> Scopes { get; set; }
+
+
+
+        public static string CreateKey(string clientId)
+        {
+            return $"{clientId}.blazorade-teams.token-request-info";
+        }
+    }
+}

--- a/Blazorade.Teams/_Imports.razor
+++ b/Blazorade.Teams/_Imports.razor
@@ -1,5 +1,5 @@
 ﻿@using Microsoft.AspNetCore.Components.Web
-@using Microsoft.JSInterop; 
+@using Microsoft.JSInterop;
 @using Blazorade.Core.Components
 @using Blazorade.Core.Components.Builder
 @using Blazorade.Core.Components.Server
@@ -8,8 +8,9 @@
 @using Blazorade.Msal.Components
 @using Blazorade.Msal.Configuration
 @using Blazorade.Msal.Security
-@using Blazorade.Msal.Services   
+@using Blazorade.Msal.Services
 
 @using Blazorade.Teams.Components
-@using Blazorade.Teams.Configuration 
-@using Blazorade.Teams.Interop 
+@using Blazorade.Teams.Configuration
+@using Blazorade.Teams.Interop
+@using Blazorade.Teams.Interop.Internal

--- a/Samples/TeamsTabAppClient/Pages/Personal.razor
+++ b/Samples/TeamsTabAppClient/Pages/Personal.razor
@@ -1,6 +1,6 @@
 ﻿@page "/personal"
 
-<TeamsApplication RequireAuthentication="true">
+<TeamsApplication RequireDefaultScopes="true">
     <ApplicationTemplate Context="ctx">
         <h2>Basic Profile Info for @ctx.AuthResult.IdTokenClaims["name"]</h2>
         <ProfileViewer Context="ctx" />

--- a/Samples/TeamsTabAppServer/Pages/MyCalendar.razor
+++ b/Samples/TeamsTabAppServer/Pages/MyCalendar.razor
@@ -1,0 +1,10 @@
+﻿@page "/mycalendar"
+
+<TeamsApplication RequireScopes="User.Read,Calendars.Read">
+    <ApplicationTemplate>
+        <h2>My Calendar...</h2>
+    </ApplicationTemplate>
+    <LoadingTemplate>
+        <p>Loading...</p>
+    </LoadingTemplate>
+</TeamsApplication>

--- a/Samples/TeamsTabAppServer/Pages/MyInfo.razor
+++ b/Samples/TeamsTabAppServer/Pages/MyInfo.razor
@@ -1,0 +1,10 @@
+﻿@page "/myinfo"
+
+<TeamsApplication RequireScopes="User.Read">
+    <ApplicationTemplate>
+        <UserInfoView Context="context" />
+    </ApplicationTemplate>
+    <LoadingTemplate>
+        <p>Loading...</p>
+    </LoadingTemplate>
+</TeamsApplication>

--- a/Samples/TeamsTabAppServer/Pages/MyMail.razor
+++ b/Samples/TeamsTabAppServer/Pages/MyMail.razor
@@ -1,0 +1,10 @@
+﻿@page "/mymail"
+
+<TeamsApplication RequireScopes="User.Read,Mail.Read">
+    <ApplicationTemplate>
+        <MailView Context="context" />
+    </ApplicationTemplate>
+    <LoadingTemplate>
+        <p>Loading...</p>
+    </LoadingTemplate>
+</TeamsApplication>

--- a/Samples/TeamsTabAppServer/Pages/Personal.razor
+++ b/Samples/TeamsTabAppServer/Pages/Personal.razor
@@ -1,6 +1,6 @@
 ﻿@page "/personal"
 
-<TeamsApplication RequireAuthentication="true">
+<TeamsApplication RequireDefaultScopes="true">
     <ApplicationTemplate Context="ctx">
         <UserInfoView Context="ctx" />
     </ApplicationTemplate>

--- a/Samples/TeamsTabAppServer/Shared/MailView.razor
+++ b/Samples/TeamsTabAppServer/Shared/MailView.razor
@@ -1,0 +1,14 @@
+﻿@inherits BlazoradeComponentBase
+@inject BlazoradeMsalService MsalService
+
+<h3>Mail</h3>
+
+@if(this.Messages?.Count() > 0)
+{
+    <ul>
+        @foreach(var msg in this.Messages)
+        {
+            <li>@msg.ReceivedDateTime | @msg.Sender.EmailAddress.Name (<a href="mailto:@msg.Sender.EmailAddress.Address">@msg.Sender.EmailAddress.Address</a>) | @msg.Subject</li>
+        }
+    </ul>
+}

--- a/Samples/TeamsTabAppServer/Shared/MailView.razor.cs
+++ b/Samples/TeamsTabAppServer/Shared/MailView.razor.cs
@@ -1,0 +1,30 @@
+﻿using Blazorade.Teams.Model;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Graph;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace TeamsTabAppServer.Shared
+{
+    partial class MailView
+    {
+        [Parameter]
+        public ApplicationContext Context { get; set; }
+
+        [Parameter]
+        public IEnumerable<Message> Messages { get; set; }
+
+
+
+        protected async override Task OnParametersSetAsync()
+        {
+            await base.OnParametersSetAsync();
+
+            var authProvider = new AuthenticationProvider(this.Context, this.MsalService);
+            var client = new GraphServiceClient(authProvider);
+            this.Messages = await client.Me.MailFolders.Inbox.Messages.Request().GetAsync();
+        }
+    }
+}

--- a/Samples/TeamsTabAppServer/Startup.cs
+++ b/Samples/TeamsTabAppServer/Startup.cs
@@ -30,6 +30,8 @@ namespace TeamsTabAppServer
                     c.TenantId = config.GetValue<string>("tenantId");
 
                     c.LoginUrl = "/login";
+
+                    c.DefaultScopes = new string[] { "User.Read" };
                 });
         }
 


### PR DESCRIPTION
Scopes can now be specified in two different ways.

- In the application's startup configuration you define a default set of scopes that will be included when acquiring tokens, if the scopes are not specified explicitly.
- On the `TeamsApplication` scope you define the set of scopes that application page requires.

The `TeamsApplication` component is changed in the following way.
- `RequireAuthentication` parameter is removed.
- `RequireDefaultScopes` - A boolean parameter that specifies that the application requires the default scopes defined in startup.
- `RequireScopes` - A string representing a comma-separated list of scopes to request when acquiring tokens for the application page.
