### PR TITLE
Support for client time zone

### DIFF
--- a/Blazorade.Teams/Components/TeamsApplication.razor
+++ b/Blazorade.Teams/Components/TeamsApplication.razor
@@ -3,8 +3,8 @@
 @inject NavigationManager NavMan
 @inject BlazoradeTeamsOptions AppOptions
 @inject BlazoradeMsalService MsalService
+@inject BlazoradeLocalizationService LocalizationService
 @inject IJSRuntime JSRuntime
-
 
 @if (this.ShowApplicationTemplate && null != this.ApplicationTemplate)
 {

--- a/Blazorade.Teams/Components/TeamsApplication.razor.cs
+++ b/Blazorade.Teams/Components/TeamsApplication.razor.cs
@@ -180,13 +180,25 @@ namespace Blazorade.Teams.Components
         /// </remarks>
         private async Task InitializeAsync()
         {
-
             //---------------------------------------------------------------------------------------
             // First we have to do some basic initialization. This will for instance remove the
             // loading icon from Teams so that the application can start rendering a UI.
             await this.TeamsInterop.InitializeAsync();
             await this.TeamsInterop.AppInitialization.NotifyAppLoadedAsync();
             //---------------------------------------------------------------------------------------
+
+
+            //---------------------------------------------------------------------------------------
+            // Now we'll get the client's time zone offset and store it in the application context
+            // so that it is available to code running later on.
+            try
+            {
+                this.ApplicationContext.ClientTimeZoneOffset = await this.LocalizationService
+                    .GetClientTimezoneOffsetAsync();
+            }
+            catch { }
+            //---------------------------------------------------------------------------------------
+
 
             //---------------------------------------------------------------------------------------
             // Now we'll get the context from Teams. When we have it, we'll store it in the

--- a/Blazorade.Teams/Configuration/BlazoradeTeamsConfigurationMethods.cs
+++ b/Blazorade.Teams/Configuration/BlazoradeTeamsConfigurationMethods.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddScoped<SettingsModule>()
                 .AddScoped<AuthenticationModule>()
                 .AddScoped<LocalStorageService>()
+                .AddBlazoradeCore()
                 .AddBlazoradeMsal((sp, config) =>
                 {
                     var options = sp.GetService<BlazoradeTeamsOptions>();

--- a/Blazorade.Teams/Model/ApplicationContext.cs
+++ b/Blazorade.Teams/Model/ApplicationContext.cs
@@ -15,6 +15,8 @@ namespace Blazorade.Teams.Model
 
         public AuthenticationResult AuthResult { get; internal set; }
 
+        public TimeSpan? ClientTimeZoneOffset { get; set; }
+
         public BlazoradeTeamsInteropModule TeamsInterop { get; internal set; }
 
     }

--- a/Blazorade.Teams/_Imports.razor
+++ b/Blazorade.Teams/_Imports.razor
@@ -1,8 +1,10 @@
 ﻿@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.JSInterop;
+
 @using Blazorade.Core.Components
 @using Blazorade.Core.Components.Builder
 @using Blazorade.Core.Components.Server
+@using Blazorade.Core.Services
 
 @using Blazorade.Msal
 @using Blazorade.Msal.Components

--- a/Samples/TeamsTabAppServer/Shared/UserInfoView.razor
+++ b/Samples/TeamsTabAppServer/Shared/UserInfoView.razor
@@ -10,4 +10,5 @@
     <li>Job Title: @this.JobTitle</li>
     <li>Mobile Phone: @this.MobilePhone</li>
     <li>E-mail: @this.Email</li>
+    <li>Client Time Zone: @this.Context.ClientTimeZoneOffset</li>
 </ul>


### PR DESCRIPTION
The ApplicationContext now contains a property that exposes the time zone offset on the client. Closes #17 