### PR TITLE
Added notify succes to Teams, in case authentiation is not handled

### DIFF
--- a/Blazorade.Teams/Components/TeamsApplication.razor.cs
+++ b/Blazorade.Teams/Components/TeamsApplication.razor.cs
@@ -152,6 +152,8 @@ namespace Blazorade.Teams.Components
                     }
                     else
                     {
+                        await this.TeamsInterop.AppInitialization.NotifySuccessAsync();
+
                         this.ShowApplicationTemplate = true;
                         this.StateHasChanged();
                     }


### PR DESCRIPTION
When no extra scopes were needed (Auth is handled with MSAL outside of Teams for example), Teams is never notified and will show an error after a few seconds. Added notifcation back to Teams.